### PR TITLE
androidApp: Fix Hokkien date formats

### DIFF
--- a/androidApp/src/main/java/app/opass/ccip/android/ui/screens/schedule/ScheduleScreen.kt
+++ b/androidApp/src/main/java/app/opass/ccip/android/ui/screens/schedule/ScheduleScreen.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import app.opass.ccip.android.R
 import app.opass.ccip.android.ui.composable.SearchAppBarComposable
 import app.opass.ccip.android.ui.composable.SessionComposable
+import app.opass.ccip.android.utils.DateTimeUtil
 import app.opass.ccip.network.models.schedule.Session
 import kotlinx.coroutines.launch
 
@@ -47,10 +48,9 @@ fun ScheduleScreen(
 
     ScreenContent(
         sessions = schedule?.sessions?.groupBy {
-            DateUtils.formatDateTime(
+            DateTimeUtil.formatShowDate(
                 context,
-                viewModel.sdf.parse(it.start)!!.time,
-                DateUtils.FORMAT_SHOW_DATE
+                viewModel.sdf.parse(it.start)!!.time
             )
         } ?: emptyMap(),
         searchResult = searchResult,

--- a/androidApp/src/main/java/app/opass/ccip/android/utils/DateTimeUtil.kt
+++ b/androidApp/src/main/java/app/opass/ccip/android/utils/DateTimeUtil.kt
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: 2025 OPass
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+package app.opass.ccip.android.utils
+
+import android.content.Context
+import android.text.format.DateUtils
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object DateTimeUtil {
+
+    private fun isCurrentYear(millis: Long): Boolean {
+        val year = SimpleDateFormat("yyyy", Locale.getDefault())
+            .format(Date(millis))
+
+        val currentYear = SimpleDateFormat("yyyy", Locale.getDefault())
+            .format(Date())
+
+        return year == currentYear
+    }
+
+    fun formatShowDate(
+         context: Context?,
+         millis: Long
+    ): String {
+        val locale = Locale.getDefault()
+        val isCurrentYear = isCurrentYear(millis)
+        val pattern = when (locale.toLanguageTag()) {
+            "nan-Hant-TW" -> {
+                if (isCurrentYear) "M'月'd'日'" else "yyyy'年'M'月'd'日'"
+            }
+
+            "nan-Latn-TW-pehoeji" -> {
+                if (isCurrentYear) "M 'goe̍h' d 'ji̍t'" else "yyyy 'nî' M 'goe̍h' d 'ji̍t'"
+            }
+
+            "nan-Latn-TW-tailo" -> {
+                if (isCurrentYear) "M 'gue̍h' d 'ji̍t'" else "yyyy 'nî' M 'gue̍h' d 'ji̍t'"
+            }
+
+            else -> null
+        }
+
+        if (pattern != null) {
+            return SimpleDateFormat(pattern, locale).format(Date(millis))
+        }
+
+        return DateUtils.formatDateTime(
+            context,
+            millis,
+            DateUtils.FORMAT_SHOW_DATE
+        )
+    }
+}


### PR DESCRIPTION
Hokkien date formats are not supported in `android.text.format.DateUtils`, produce confusing "M08 9", "2024 M08 3" formats.

This commit used a wrapper utility function to specify format patterns in specific locales as a workaround.

Change-Id: I7a0da7af2ad3d6ad26e30eb334e61424a0517941