### PR TITLE
shared: Use zh instead of en for nan in localized

### DIFF
--- a/shared/src/commonMain/kotlin/app/opass/ccip/extensions/Localization.kt
+++ b/shared/src/commonMain/kotlin/app/opass/ccip/extensions/Localization.kt
@@ -19,6 +19,7 @@ internal fun LocalizedString.localized() = localized(this.en, this.zh)
  */
 internal fun localized(en: String, zh: String): String {
     return when (languageCode) {
+        "nan" -> zh
         "zh" -> zh
         else -> en
     }


### PR DESCRIPTION
Use Mandarin instead of English for Hokkien texts in `app.opass.ccip.extensions.localized`.

Change-Id: I83fe3877995ab23f14be9237f2d2d5689637868e